### PR TITLE
Include dir name in error when passed as source to CopyFile

### DIFF
--- a/cp.go
+++ b/cp.go
@@ -3,6 +3,7 @@ package cp
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func copyFile(dst, src string, flag int) error {
 		return err
 	}
 	if rstat.IsDir() {
-		return errCopyFileWithDir
+		return fmt.Errorf("%w: %s", errCopyFileWithDir, src)
 	}
 
 	wf, err := os.OpenFile(dst, flag, rstat.Mode())

--- a/cp_test.go
+++ b/cp_test.go
@@ -2,6 +2,7 @@ package cp
 
 import (
 	"io/ioutil"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -28,7 +29,7 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	td.mkdir("d", 0755)
-	if err := CopyFile(td.path("c.txt"), td.path("d")); err != errCopyFileWithDir {
+	if err := CopyFile(td.path("c.txt"), td.path("d")); !errors.Is(err, errCopyFileWithDir) {
 		t.Errorf("CopyFile(c.txt, d): got %v; want errCopyFileWithDir", err)
 	}
 }
@@ -55,7 +56,7 @@ func TestCopyFileOverwrite(t *testing.T) {
 	}
 
 	td.mkdir("d", 0755)
-	if err := CopyFileOverwrite(td.path("b.txt"), td.path("d")); err != errCopyFileWithDir {
+	if err := CopyFileOverwrite(td.path("b.txt"), td.path("d")); !errors.Is(err, errCopyFileWithDir) {
 		t.Errorf("CopyFileOverwrite(c.txt, d): got %v; want errCopyFileWithDir", err)
 	}
 }


### PR DESCRIPTION
Fixes #3.